### PR TITLE
Use 1.9.3 instead of 1.9.1. rbx-2.0 will soon become master so it is suff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 rvm:
   - 1.8.7
-  - 1.9.1
   - 1.9.2
+  - 1.9.3
   - ree
   - jruby
-  - rbx
   - rbx-2.0
 notifications:
   recipients:


### PR DESCRIPTION
Use 1.9.3 instead of 1.9.1. rbx-2.0 will soon become master so it is sufficient.
