### PR TITLE
Rails31 compatibility branch

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use --create ruby-1.9.2-p180@simple_eav
+rvm use --create ruby-1.9.2-p290@simple_eav

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -46,7 +46,7 @@ module SimpleEav
   def simple_eav_attributes=(attributes={})
     self.send("#{simple_eav_column}=", attributes)
   end
-
+=begin
   def attributes=(_attributes={})
     #Iterate over each attribute:
     # - skip columns that are actually defined in the db
@@ -60,7 +60,7 @@ module SimpleEav
     self.simple_eav_attributes = simple_eav_attrs
     super(_attributes)
   end
-  
+=end  
   def assign_attributes(_attributes={})
     puts "\n\n\n\n I am assign Attributes!!! \n\n\n\n\n"
     #Iterate over each attribute:

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -47,11 +47,11 @@ module SimpleEav
     self.send("#{simple_eav_column}=", attributes)
   end
 
-  def attributes=(_attributes={})
+  def assign_attributes(_attributes, options={})
     #Iterate over each attribute:
     # - skip columns that are actually defined in the db
     # - remove undefined columns to prevent UnknownAttribute::Error from being thrown
-    puts "\n\n\n\n\n\n I AM Attributes= BEING CALLED \n\n\n\n\n"
+    puts "\n\n\n\n\n\n I AM Assign Attributes BEING CALLED \n\n\n\n\n"
     simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
     _attributes.each do |column,value|
       next if reserved_attribute?(column.to_sym)

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -51,7 +51,6 @@ module SimpleEav
     #Iterate over each attribute:
     # - skip columns that are actually defined in the db
     # - remove undefined columns to prevent UnknownAttribute::Error from being thrown
-    puts "\n\n\n\n\n\n I AM Assign Attributes BEING CALLED \n\n\n\n\n"
     simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
     _attributes.each do |column,value|
       next if reserved_attribute?(column.to_sym)
@@ -69,7 +68,6 @@ module SimpleEav
 
   def method_missing(method, *args, &block)
     _attributes = read_attribute(simple_eav_column.to_sym) || {}
-    puts "\n\n\n\n\n\n I AM METHOD MISSING BEING CALLED \n\n\n\n\n"
     if method.to_s =~ /=$/
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -68,6 +68,7 @@ module SimpleEav
 
   def method_missing(method, *args, &block)
     _attributes = read_attribute(simple_eav_column.to_sym) || {}
+    puts "\n\n\n\n\n\n I AM BEING CALLED BITCHES \n\n\n\n\n"
     if method.to_s =~ /=$/
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -67,13 +67,13 @@ module SimpleEav
   end
 
   def method_missing(method, *args, &block)
-    _attributes = read_attribute(simple_eav_column.to_sym) || {}
+    _attributes = read_attribute(simple_eav_column.to_sym) || {}  
     if method.to_s =~ /=$/
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift
       return self.simple_eav_attributes = _attributes
-    elsif _attributes.has_key?(method.to_sym)
-     return  _attributes[method.to_sym]
+    elsif _attributes.has_key?(method.to_sym) || _attributes.has_key?(method.to_s)
+     return  _attributes[method.to_sym] || _attributes[method.to_s]
     else
       super(method, *args, &block)
     end

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -51,6 +51,7 @@ module SimpleEav
     #Iterate over each attribute:
     # - skip columns that are actually defined in the db
     # - remove undefined columns to prevent UnknownAttribute::Error from being thrown
+    puts "\n\n\n\n\n\n I AM Attributes= BEING CALLED \n\n\n\n\n"
     simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
     _attributes.each do |column,value|
       next if reserved_attribute?(column.to_sym)
@@ -68,7 +69,7 @@ module SimpleEav
 
   def method_missing(method, *args, &block)
     _attributes = read_attribute(simple_eav_column.to_sym) || {}
-    puts "\n\n\n\n\n\n I AM METHID MISSING BEING CALLED \n\n\n\n\n"
+    puts "\n\n\n\n\n\n I AM METHOD MISSING BEING CALLED \n\n\n\n\n"
     if method.to_s =~ /=$/
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -46,23 +46,8 @@ module SimpleEav
   def simple_eav_attributes=(attributes={})
     self.send("#{simple_eav_column}=", attributes)
   end
-=begin
+
   def attributes=(_attributes={})
-    #Iterate over each attribute:
-    # - skip columns that are actually defined in the db
-    # - remove undefined columns to prevent UnknownAttribute::Error from being thrown
-    simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
-    _attributes.each do |column,value|
-      next if reserved_attribute?(column.to_sym)
-      simple_eav_attrs[column] = value
-      _attributes.delete(column)
-    end
-    self.simple_eav_attributes = simple_eav_attrs
-    super(_attributes)
-  end
-=end  
-  def assign_attributes(_attributes={})
-    puts "\n\n\n\n I am assign Attributes!!! \n\n\n\n\n"
     #Iterate over each attribute:
     # - skip columns that are actually defined in the db
     # - remove undefined columns to prevent UnknownAttribute::Error from being thrown

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -60,6 +60,21 @@ module SimpleEav
     self.simple_eav_attributes = simple_eav_attrs
     super(_attributes)
   end
+  
+  def assign_attributes(_attributes={})
+    puts "\n\n\n\n I am assign Attributes!!! \n\n\n\n\n"
+    #Iterate over each attribute:
+    # - skip columns that are actually defined in the db
+    # - remove undefined columns to prevent UnknownAttribute::Error from being thrown
+    simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
+    _attributes.each do |column,value|
+      next if reserved_attribute?(column.to_sym)
+      simple_eav_attrs[column] = value
+      _attributes.delete(column)
+    end
+    self.simple_eav_attributes = simple_eav_attrs
+    super(_attributes)
+  end
 
   def respond_to?(method, include_private=false)
     return true if super(method, include_private)

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -54,7 +54,7 @@ module SimpleEav
     simple_eav_attrs = read_attribute(simple_eav_column.to_sym) || {}
     _attributes.each do |column,value|
       next if reserved_attribute?(column.to_sym)
-      simple_eav_attrs[column] = value
+      simple_eav_attrs[column.to_sym] = value
       _attributes.delete(column)
     end
     self.simple_eav_attributes = simple_eav_attrs
@@ -72,8 +72,8 @@ module SimpleEav
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift
       return self.simple_eav_attributes = _attributes
-    elsif _attributes.has_key?(method.to_sym) || _attributes.has_key?(method.to_s)
-     return  _attributes[method.to_sym] || _attributes[method.to_s]
+    elsif _attributes.has_key?(method.to_sym)
+     return  _attributes[method.to_sym]
     else
       super(method, *args, &block)
     end

--- a/lib/simple_eav.rb
+++ b/lib/simple_eav.rb
@@ -83,7 +83,7 @@ module SimpleEav
 
   def method_missing(method, *args, &block)
     _attributes = read_attribute(simple_eav_column.to_sym) || {}
-    puts "\n\n\n\n\n\n I AM BEING CALLED BITCHES \n\n\n\n\n"
+    puts "\n\n\n\n\n\n I AM METHID MISSING BEING CALLED \n\n\n\n\n"
     if method.to_s =~ /=$/
       setter = method.to_s.gsub(/=/, '')
       _attributes[setter.to_sym] = args.shift

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module SimpleEav
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/simple_eav.gemspec
+++ b/simple_eav.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.6.0'
-  s.add_development_dependency 'pry'
 end

--- a/simple_eav.gemspec
+++ b/simple_eav.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.6.0'
+  s.add_development_dependency 'pry'
 end

--- a/simple_eav.gemspec
+++ b/simple_eav.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.rdoc" ]
   s.require_path     = "lib"
 
-  s.add_dependency 'activerecord', '~> 3.0.7'
+  s.add_dependency 'activerecord', '~> 3.1.0'
   unless ENV["CI"]
     if RUBY_VERSION <= '1.9.1'
       s.add_development_dependency 'ruby-debug'

--- a/spec/lib/simple_eav_spec.rb
+++ b/spec/lib/simple_eav_spec.rb
@@ -69,12 +69,16 @@ describe SimpleEav do
       end
     end
     describe "nested attributes" do
-      it "nests the attributes properly" do
+      it "updates the nested attributes properly" do
         child = Child.create :name=>'Joe Jr.'
         person = Person.create :child=>child
-        lambda{
-         person.update_attributes :child_attributes=>{:name=>'John Jr.'}
-        }.should change(person.child, :name).from('Joe Jr.').to('John Jr.')
+        person.child.name.should == 'Joe Jr.'
+        
+        person.update_attributes :child_attributes=>{:name=>'John Jr.'}
+        person.child.name.should == 'John Jr.'
+#        lambda{
+#         person.update_attributes :child_attributes=>{:name=>'John Jr.'}
+#        }.should change(person.child, :name).from('Joe Jr.').to('John Jr.')
       end
     end
     describe "serialization" do

--- a/spec/lib/simple_eav_spec.rb
+++ b/spec/lib/simple_eav_spec.rb
@@ -144,7 +144,7 @@ describe SimpleEav do
       @person.respond_to?(:age).should be_true
     end
 
-    it "the custome attribute `name` is responded to" do
+    it "the custom attribute `name` is responded to" do
       @person.name = 'John'
       @person.respond_to?(:name).should be_true
     end


### PR DESCRIPTION
Hey, 

I have made an attempt to make simple_eav compatible with rails 3.1. All tests are passing as given.
The Nested attributes test had to be modified the lambda call for some reason was not picking up the changed state of the nested attributes but upon checking the db the values were indeed changed.

There are some frivolous commits that can be ignored there is just one major change that was needed and it was to change the attributes=() method to assign_attributes() which is what is used in activerecord 3.1

cheers

Brett
